### PR TITLE
feat: add multi-step onboarding modal for new users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Dashboard from "./pages/Dashboard";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import NotFound from "./pages/NotFound";
 import Portfolio from "./pages/Portfolio";
+import Onboarding from "./components/ui/onboarding";
 
 const queryClient = new QueryClient();
 
@@ -21,6 +22,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
+        <Onboarding />
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />

--- a/src/components/ui/onboarding.tsx
+++ b/src/components/ui/onboarding.tsx
@@ -35,7 +35,7 @@ const STEPS = [
 
 
 export default function Onboarding() {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
     const [step, setStep] = useState(0);
 
     const skipRef = useRef<HTMLButtonElement>(null);
@@ -59,7 +59,7 @@ export default function Onboarding() {
     // Handle keyboard navigation: Arrow Left/Right for Back/Next, focus buttons on step change
     useEffect(() => {
         if (!open || focusedStep.current === step) return;
-        
+
         const target = step === 0 ? skipRef.current : nextRef.current;
         target?.focus();
         focusedStep.current = step;

--- a/src/components/ui/onboarding.tsx
+++ b/src/components/ui/onboarding.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useRef } from "react";
+import { 
+    Dialog, 
+    DialogHeader, 
+    DialogContent, 
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+    DialogClose } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+const STORAGE_KEY = "contribforge:onboardingSeen";
+
+const STEPS = [
+    {
+     title: "Welcome to ContribForge",
+     description: "A quick tour to help you find and track meaningful open-source contributions.",
+   },
+   {
+    title: "Discover Projects",
+    description:
+      "Use Search to find projects you can contribute to.",
+  },
+  {
+    title: "Save interesting projects",
+    description:
+      "Bookmark projects so you can come back later and track what you want to work on.",
+  },
+  {
+    title: "Track your progress",
+    description:
+      "Sync your contributions to see your progress and build your profile.",
+  },
+];
+
+
+export default function Onboarding() {
+    const [open, setOpen] = useState(true);
+    const [step, setStep] = useState(0);
+
+    const skipRef = useRef<HTMLButtonElement>(null);
+    const nextRef = useRef<HTMLButtonElement>(null);
+
+    // Show onboarding on first visit (if not seen before)
+    useEffect(() => {
+        try {
+            const seen = window.localStorage.getItem(STORAGE_KEY);
+            if (!seen) {
+                setOpen(true);
+            }
+        } catch (e) {
+            // If localStorage is unavailable, just show the onboarding
+            setOpen(true);
+        }
+    }, []);
+
+    const focusedStep = useRef<number | null>(null);
+
+    // Handle keyboard navigation: Arrow Left/Right for Back/Next, focus buttons on step change
+    useEffect(() => {
+        if (!open || focusedStep.current === step) return;
+        
+        const target = step === 0 ? skipRef.current : nextRef.current;
+        target?.focus();
+        focusedStep.current = step;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "ArrowLeft") {
+                e.preventDefault();
+                handleBack();
+            } else if (e.key === "ArrowRight") {
+                e.preventDefault();
+                handleNext();
+            }
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [open, step]);
+
+
+    const markSeenAndClose = () => {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, "true");
+        } catch (e) {
+            // Ignore localStorage errors
+        }
+        setStep(0);
+        setOpen(false);
+    };
+
+    const handleNext = () => {
+        if (step < STEPS.length - 1) {
+            setStep(step + 1);
+        } else {
+            // Last step, mark as seen and close
+            markSeenAndClose();
+        }
+    };
+
+    const handleBack = () => setStep((s) => Math.max(0, s - 1))
+
+    const handleSkip = () => markSeenAndClose();
+
+    return (
+        <Dialog open={open} onOpenChange={(val) => {
+                if (!val) markSeenAndClose();
+                setOpen(val)
+            }}>
+            <DialogContent aria-label="Onboarding tutorial">
+                <DialogHeader>
+                    <DialogTitle>{STEPS[step].title}</DialogTitle> 
+                    <DialogDescription>{STEPS[step].description}</DialogDescription>
+                </DialogHeader>
+
+                {/* Screen reader announcement for current step */}
+                <div aria-live="polite" aria-atomic="true" className="sr-only">
+                    Step {step + 1} of {STEPS.length}: {STEPS[step].title}
+                </div>
+
+                {/* Main content for onboarding */}
+                <div className="mt-4 text-sm">
+                    {step === 0 && (
+                        <p>
+                            Explore the curated list of projects, or try searching for ‘good first issue’ to get started.
+                        </p>
+                    )}
+                    {step === 1 && (
+                        <p>
+                            Try filters like language, difficulty, or labels to find issues that match your
+                            skill level and interests.
+                        </p>
+                    )}
+                    {step === 2 && (
+                        <p>
+                            You’ll need to log in to bookmark projects.
+                        </p>
+                    )}
+                    {step === 3 && (
+                        <p>
+                            Once you contribute, sync GitHub to track progress, your accepted contributions will appear in your public portfolio.
+                        </p>
+                    )}
+                </div>
+
+                <div className="flex items-center justify-center gap-2">
+                    {STEPS.map((_, i) => (
+                        <span
+                        key={i}
+                        className={`h-2 w-2 rounded-full ${
+                            i === step ? "bg-primary" : "bg-muted"
+                        }`}
+                        aria-label={`Step ${i + 1} of ${STEPS.length}`}
+                        role="progressbar"
+                        aria-valuenow={i + 1}
+                        aria-valuemin={1}
+                        aria-valuemax={STEPS.length}
+                        />
+                    ))}
+                </div>
+
+                <DialogFooter>
+                    {/* Back (hidden on first step) */}
+                    <div className="flex items-center gap-2">
+                        <Button variant="outline" size="sm" onClick={handleSkip} ref={skipRef}>
+                          Skip
+                        </Button>
+
+                        <div className="flex-1" />
+
+                        {step > 0 && (
+                            <Button variant="outline" size="sm" onClick={handleBack}>
+                                Back
+                            </Button>
+                        )}
+                        
+                        <Button onClick={handleNext} size="sm" ref={nextRef}>
+                            {step < STEPS.length - 1 ? "Next" : "Get started"}
+                        </Button>
+                    </div>
+                </DialogFooter>
+
+                {/* Close icon in top-right comes from `DialogContent` implementation */}
+                <DialogClose asChild>
+                {/* Keep this visually hidden unless you want an extra close button inside the footer */}
+                <button aria-hidden className="hidden" />
+                </DialogClose>
+            </DialogContent>
+        </Dialog>
+    )
+}


### PR DESCRIPTION
Adds a multi-step, keyboard-accessible onboarding modal to guide new users through searching issues, bookmarking projects, and tracking contributions.


**Problem addressed**  
New users don’t always know how to use ContribForge effectively. The issue highlighted that onboarding should explain:

- How to search issues  
- Bookmark projects  
- Track contributions  

**Enhancement implemented**  
This PR adds a multi-step onboarding modal that guides new users through the key flows:

1. Welcome and overview of ContribForge  
2. Searching for projects and issues  
3. Bookmarking interesting projects  
4. Tracking contribution progress  

**Screenshots**
<img width="1354" height="622" alt="Screenshot 2026-02-17 15 39 22" src="https://github.com/user-attachments/assets/6968521e-3e7f-41bc-a691-a42341bed759" />

<img width="1354" height="622" alt="Screenshot 2026-02-17 15 39 32" src="https://github.com/user-attachments/assets/c1ca9e58-35d2-4d4f-aec7-b667584f934f" />
  


**Accessibility / UX**  
- Keyboard accessible: Skip, Back, and Next buttons are fully navigable  
- Default focus is on the main action button per step, but Skip is always reachable via Tab  
- Step progress indicated with dots and ARIA live announcements for screen readers  
- LocalStorage used to prevent showing onboarding repeatedly for returning users  

**Related issue**  
Closes #3  

**Outcome / Benefit**  
- Provides a clear, accessible introduction to the app’s core features  

**Notes / Future improvements**  
- Could add visual pointers or highlights on actual UI elements for even better guidance  
